### PR TITLE
Add placeholder for homepage in package.yml generation

### DIFF
--- a/Scripts/yauto.py
+++ b/Scripts/yauto.py
@@ -258,6 +258,7 @@ version    : %(VERSION)s
 release    : 1
 source     :
     - %(SOURCE)s : %(SHA256SUM)s
+homepage   : PLEASE FILL ME IN
 license    : GPL-2.0-or-later # CHECK ME
 component  : %(COMPONENT)s\n""" % mapping
 


### PR DESCRIPTION
We require that package.yml has a "homepage" value but had not added this to the script that generates the initial package.yml file. This adds that field.

Tested by running the script in a repo without a package.yml. Verified that package.yml was created with expected output, and that it includes the homepage field.