### PR TITLE
Add more features to go-task

### DIFF
--- a/Scripts/clone-all.py
+++ b/Scripts/clone-all.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess as sp
+import concurrent.futures
+import argparse
+
+def clone_all(base_repo, pkg, failed_pkgs):
+    try:
+        if os.path.exists(pkg):
+            sp.run(["git", "-C", f"{pkg}", "pull"], check=True)
+        else:
+            sp.run(["git", "clone", f"https://{base_repo}{pkg}.git"], check=True)
+            sp.run(["git", "-C", f"{pkg}", "remote", "set-url", "origin", f"https://{base_repo}{pkg}.git"])
+            sp.run(["git", "-C", f"{pkg}", "remote", "set-url", "--push", "origin", f"git@{base_repo}{pkg}.git"])
+    except Exception:
+        failed_pkgs.append(pkg)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-j",
+        type=int,
+        default=1,
+        choices=range(1, 31),
+        help="Set the number of concurrent jobs e.g -j20"
+    )
+    args = parser.parse_args()
+
+    pkgs_fpath = "common/packages"
+    pkgs = []
+    base_repo = "github.com/solus-packages/"
+
+    try:
+        with open(pkgs_fpath, "r") as file:
+            for line in file:
+                pkgs.append(line.strip())
+    except FileNotFoundError:
+        print(f"File not found: {pkgs_fpath}")
+
+    try:
+        while True:
+            failed_pkgs = []
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=args.j) as executor:
+                futures = {executor.submit(clone_all, base_repo, pkg, failed_pkgs) for pkg in pkgs}
+
+            if not failed_pkgs:
+                break
+
+            print(f"\n{failed_pkgs} packages failed")
+            retry = input("Would you like to retry (y/n?)\n").lower()
+            if retry not in ["yes", "y"]:
+                break
+    except KeyboardInterrupt:
+        executor.shutdown(cancel_futures=True)
+        print("Script terminated by ctrl+c.")
+
+main()

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,7 +20,7 @@ tasks:
         msg: Either `package.yml` or `pspec.xml` must exists in the current directory
 
   # Build packages
-  build: 
+  build:
     desc: Build the current package against the unstable repo
     aliases: [default]
     dir: '{{ .USER_WORKING_DIR }}'
@@ -36,7 +36,7 @@ tasks:
     aliases: [stable]
     cmds:
       - task: build
-        vars: 
+        vars:
           PROFILE: 'main-x86_64'
       - |
         echo "=========================================================================="
@@ -50,7 +50,7 @@ tasks:
     aliases: [local]
     cmds:
       - task: build
-        vars: 
+        vars:
           PROFILE: 'local-unstable-x86_64'
 
   # Modify packages
@@ -65,7 +65,7 @@ tasks:
       - package-file
     cmds:
       - python {{ .BUMP_SCRIPT }} {{ .SPECFILE }}
-  
+
   convert:
     desc: Convert pspec to package.yml
     dir: '{{ .USER_WORKING_DIR }}'
@@ -151,3 +151,40 @@ tasks:
     desc: Update local repositories to use correct hostname
     cmds:
       - go run "{{ .TASKFILE_DIR }}/common/Go/switch_repo_domains.go"
+
+  pkgconfig:
+    desc: Find which package provides a given pkgconfig. Example usage `go-task pkgconfig -- Qt5Core Qt6Core`
+    cmds:
+      - python {{ .TASKFILE_DIR }}/common/Scripts/epcsearch.py {{ .CLI_ARGS }}
+
+  clone:
+    desc: Clone a given packages source repo. Example usage `go-task clone -- reponame`
+    cmds:
+      - |
+        if [ -d "{{.CLI_ARGS}}" ]; then
+          echo "Clone already exists"
+        else
+            git clone https://github.com/solus-packages/{{ .CLI_ARGS }}.git
+            git -C "{{ .CLI_ARGS }}" remote set-url origin "https://github.com/solus-packages/{{ .CLI_ARGS }}.git"
+            git -C "{{ .CLI_ARGS }}" remote set-url --push origin "git@github.com:solus-packages/{{ .CLI_ARGS }}.git"
+        fi
+
+  clone-all:
+    desc: Clone all Solus package source repos (You probably do not want to do this)
+    cmds:
+        - python3 {{ .TASKFILE_DIR }}/common/Scripts/clone-all.py {{ .CLI_ARGS }}
+
+  update-tooling:
+    aliases: [up]
+    desc: Update common, infrastructure-tooling and all solbuild profiles present
+    cmds:
+      - git -C {{ .TASKFILE_DIR }}/common pull
+      - |
+        if [ -d "{{ .TASKFILE_DIR }}/infrastructure-tooling" ]; then
+          git -C {{ .TASKFILE_DIR}}/infrastructure-tooling pull
+        fi
+      - sudo solbuild update
+      - |
+        if [ -f /usr/share/solbuild/main-x86_64.profile ]; then
+          sudo solbuild update -p main-x86_64
+        fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,11 @@
 version : '3'
 
+includes:
+  infra:
+    dir: "{{ .ROOT_DIR }}"
+    taskfile: infrastructure-tooling/Infra.yml
+    optional: true
+
 set: [pipefail]
 
 vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -155,7 +155,7 @@ tasks:
   pkgconfig:
     desc: Find which package provides a given pkgconfig. Example usage `go-task pkgconfig -- Qt5Core Qt6Core`
     cmds:
-      - python {{ .TASKFILE_DIR }}/common/Scripts/epcsearch.py {{ .CLI_ARGS }}
+      - python {{ .ROOT_DIR }}/common/Scripts/epcsearch.py {{ .CLI_ARGS }}
 
   clone:
     desc: Clone a given packages source repo. Example usage `go-task clone -- reponame`


### PR DESCRIPTION
- pkgconfig search
- clone
- clone-all (Multi-threaded)
- update-tooling

It has been discussed possibly having some of these under a separate taskfile imported under the common name space. So it is accessed via `go-task common:clone` for example.

I am not entirely sure which functions should be moved to a separate taskfile or the value-add of doing so. I would like to avoid command complexity. Example `go-task common:pkgconfig -- pkgconfig` is a bit ridiculous, I hate having -- as it is.