### PR TITLE
Update Go tasks for monorepo

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,7 +20,7 @@ tasks:
         msg: Either `package.yml` or `pspec.xml` must exists in the current directory
 
   # Build packages
-  build: 
+  build:
     desc: Build the current package against the unstable repo
     aliases: [default]
     dir: '{{ .USER_WORKING_DIR }}'
@@ -36,7 +36,7 @@ tasks:
     aliases: [stable]
     cmds:
       - task: build
-        vars: 
+        vars:
           PROFILE: 'main-x86_64'
       - |
         echo "=========================================================================="
@@ -50,7 +50,7 @@ tasks:
     aliases: [local]
     cmds:
       - task: build
-        vars: 
+        vars:
           PROFILE: 'local-unstable-x86_64'
 
   # Modify packages
@@ -65,7 +65,7 @@ tasks:
       - package-file
     cmds:
       - python {{ .BUMP_SCRIPT }} {{ .SPECFILE }}
-  
+
   convert:
     desc: Convert pspec to package.yml
     dir: '{{ .USER_WORKING_DIR }}'
@@ -81,56 +81,42 @@ tasks:
     desc: Tag and publish a release
     dir: '{{ .USER_WORKING_DIR }}'
     preconditions:
-      - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/master"
-        msg: Not on master branch
-      - sh: '! git show-ref --quiet --tags {{ .TAG }}'
-        msg: Tag already exists! Did you mean to call `go-task republish`?
+      - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/main"
+        msg: Not on main branch
       - sh: "{{ .TASKFILE_DIR }}/common/Scripts/package-publish-safety-catches.sh"
         msg: Failed to pass safety catches
     deps:
       - package-file
-    vars:
-      TAG:
-        sh: if [ -f {{ .SPECFILE }} ]; then {{ .TASKFILE_DIR }}/common/Scripts/gettag.py {{ .USER_WORKING_DIR }}/{{ .SPECFILE }}; fi;
-      SIGNTAG:
-        sh: if [ "$(git config commit.gpgsign)" == "true" ]; then echo "-s"; else echo " "; fi;
     cmds:
-      - git tag {{ .SIGNTAG }} -a -m "Publish {{ .TAG }}" {{ .TAG }}
-      - git push --follow-tags
+      - git push
       - task: push
-        vars:
-          SOURCE:
-            sh: basename '{{ .USER_WORKING_DIR }}'
-          TAG: '{{ .TAG }}'
 
   republish:
     desc: Rebuild existing tag
     dir: '{{ .USER_WORKING_DIR }}'
     preconditions:
-      - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/master"
-        msg: Not on master branch
-      - sh: git show-ref --quiet --tags {{ .TAG }}
-        msg: Tag doesn't exists! Did you mean to call `go-task publish`?
+      - sh: test $(git symbolic-ref HEAD 2>/dev/null) = "refs/heads/main"
+        msg: Not on main branch
       - sh: "{{ .TASKFILE_DIR }}/common/Scripts/package-publish-safety-catches.sh"
         msg: Failed to pass safety catches
-    vars:
-      TAG:
-        sh: if [ -f {{ .SPECFILE }} ]; then {{ .TASKFILE_DIR }}/common/Scripts/gettag.py {{ .USER_WORKING_DIR }}/{{ .SPECFILE }}; fi;
     cmds:
       - task: push
-        vars:
-          SOURCE:
-            sh: basename '{{ .USER_WORKING_DIR }}'
-          TAG: '{{ .TAG }}'
 
   push:
     desc: Push package to the build server
     internal: true
     dir: '{{ .USER_WORKING_DIR }}'
-    requires:
-      vars: [SOURCE, TAG]
+    vars:
+      SOURCE:
+        sh: basename '{{ .USER_WORKING_DIR }}'
+      TAG:
+        sh: if [ -f {{ .SPECFILE }} ]; then {{ .TASKFILE_DIR }}/common/Scripts/gettag.py {{ .USER_WORKING_DIR }}/{{ .SPECFILE }}; fi
+      PATH:
+        sh: git rev-parse --show-prefix
+      REF:
+        sh: git rev-parse HEAD
     cmds:
-      - ssh build-controller@build.getsol.us build "{{ .SOURCE }}" "{{ .TAG }}"
+      - ssh build-controller@build.getsol.us build "{{ .SOURCE }}" "{{ .TAG }}" "{{ .PATH }}" "{{ .REF }}"
 
   # Other utilities
   clean:


### PR DESCRIPTION
This updates the `publish` and `republish` targets for the build changes from https://github.com/getsolus/infrastructure-tooling/pull/3.